### PR TITLE
Update sidebar icons and message list layout

### DIFF
--- a/in.css
+++ b/in.css
@@ -115,7 +115,7 @@ body._in,
 
 /* Menu item row */
 ._in .TK .TO {
-  border-radius: 5px !important;
+  border-radius: 2px !important;
 }
 
 /* Menu item row active */
@@ -134,8 +134,17 @@ body._in,
 }
 
 /* Menu container */
+._in .aeN {
+  width: 232px !important;
+  max-width: unset !important;
+  min-width: unset !important;
+}
 ._in .wT {
   padding-top: 4px;
+  max-width: unset;
+  min-width: unset;
+  width: 224px;
+  padding: 12px 8px 52px;
 }
 
 /* Menu item sections */

--- a/in.css
+++ b/in.css
@@ -159,16 +159,79 @@ body._in,
 ._in .wT > .n3 .byl:first-child .aim:first-child .nZ {
   background-color: rgba(0,0,0,.05) !important; 
 }
-._in .nZ > .aHS-bnt .qj {
-  background-image: url("https://www.gstatic.com/images/icons/material/system/1x/inbox_black_20dp.png") !important;
+.qj {
+  width: 24px !important;
+  height: 24px !important;
+  opacity: 1 !important;
+  margin-right: 24px !important;
 }
-
-._in .nZ .afM {
-  background-image: url('https://www.gstatic.com/images/icons/material/system/1x/arrow_drop_down_black_20dp.png') !important;
+.qj::before {
+  content: none !important;
 }
-
-._in .byl .TO.nZ > .aHS-bnt .n0, .nZ>.aHS-bnt .bsU {
-  color: #000 !important;
+.qj::after {
+  content: none !important;
+}
+/* Inbox */
+._in .aHS-bnt .qj {
+  background-image: url("//www.gstatic.com/images/icons/material/system/2x/inbox_googblue_24dp.png") !important;
+  background-size: 24px !important;
+}
+/* Dropdown arrow */
+._in .aHS-bnt .afM {
+  background-image: url('//www.gstatic.com/images/icons/material/system/2x/arrow_drop_down_black_20dp.png') !important;
+}
+/* Starred */
+._in .aHS-bnw {
+  display: none;
+}
+/* Snoozed */
+._in .aHS-bu1 .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_upcoming_clr_24dp_r5_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Important */
+._in .aHS-bns {
+  display: none;
+}
+/* Chats */
+._in .aHS-aHP {
+  display: none;
+}
+/* Sent */
+._in .aHS-bnu .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_sent_right_g60_24dp_r1_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Drafts */
+._in .aHS-bnq .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_draft_g60_24dp_r2_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Trash */
+._in .aHS-bnx .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_trash_g60_24dp_r2_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Category */
+._in .aHS-bnr .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_custom-cluster_24px_g60_r3_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Done */
+._in .aHS-aHO .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_done_clr_24dp_r4_2x.png") !important;
+  background-size: 24px !important;
+}
+/* Spam */
+._in .aHS-bnv .qj {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_spam_g60_24dp_r2_2x.png") !important;
+  background-size: 24px !important;
+}
+.TO.nZ .n0 {
+  color: #212121 !important;
+}
+.TO .n0 {
+  color: #616161 !important;
 }
 
 /**

--- a/in.css
+++ b/in.css
@@ -334,6 +334,9 @@ body._in,
 ._in .brq {
   background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_done_black_24dp.png");
 }
+.pW {
+  opacity: 1 !important;
+}
 
 /**
  * Other elements 

--- a/in.css
+++ b/in.css
@@ -334,6 +334,9 @@ body._in,
 ._in .brq {
   background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/1x/btw_ic_done_black_24dp.png");
 }
+._in .brq.pW {
+  background-image: url("//ssl.gstatic.com/bt/C3341AA7A1A076756462EE2E5CD71C11/2x/ic_mark-done_clr_24dp_r4_2x.png");
+}
 .pW {
   opacity: 1 !important;
 }

--- a/in.css
+++ b/in.css
@@ -138,6 +138,9 @@ body._in,
   width: 232px !important;
   max-width: unset !important;
   min-width: unset !important;
+  position: absolute !important;
+  left: 0;
+  z-index: 999;
 }
 ._in .wT {
   padding-top: 4px;
@@ -246,6 +249,12 @@ body._in,
 /**
  * Center message list section
  **/
+
+/* Message list header */
+._in .aeH {
+  width: 1200px;
+  margin: 0 auto;
+}
 
 /* Message list wrapper */
 ._in .AO .aeF {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description" : "Brings the Google Inbox experience to Gmail",
   "homepage_url": "http://flowapps.co/inboxtheme",
   "author": "Kalle Persson",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "icons": {
     "16": "img/icon-256.png",
     "19": "img/icon-256.png",


### PR DESCRIPTION
Hi @kallepersson 

This PR is for #8 #9 #10 #11 .

Updated icons:

- Inbox
- Snoozed
- Sent
- Drafts
- Trash
- Category
- All Mail
- Spam

It will look like:

<img width="2044" alt="2018-10-05 12 17 17" src="https://user-images.githubusercontent.com/579145/46515852-e0637a00-c898-11e8-9e0a-be5572389fa2.png">
