### PR TITLE
Fix undo button

### DIFF
--- a/in.css
+++ b/in.css
@@ -186,7 +186,6 @@ body._in,
   max-width: unset !important;
   min-width: unset !important;
   left: 0;
-  z-index: 5;
 }
 ._in .wT {
   padding-top: 4px;


### PR DESCRIPTION
#34 

Before:

Menu is over hovering box, so that can not click undo button.

![image](https://user-images.githubusercontent.com/579145/52778216-75b11f00-3080-11e9-9705-a1a6b00963cc.png)

After:

Remove `z-index` from menu.

![image](https://user-images.githubusercontent.com/579145/52778161-4f8b7f00-3080-11e9-801c-94567cfee378.png)
